### PR TITLE
Updated code to send date and time in UTC

### DIFF
--- a/src/inc/init.php
+++ b/src/inc/init.php
@@ -8,6 +8,9 @@
     // Composer autoload
     require('vendor/autoload.php');
 
+    // TimeZone config
+    date_default_timezone_set('Etc/UCT');
+
     // Twig setup
     $loader = new Twig_Loader_Filesystem('views');
     $twig = new Twig_Environment($loader, array(

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -44,10 +44,19 @@
                     }
                 })
                 .find('.timestamp-checkbox').on('click', function (ev) {
-                    var $this = $(this);
+                    var $this = $(this),
+                        $timestamp = $this.next().children('.timestamp'),
+                        $checkbox = $this.find('input'),
+                        now;
 
-                    $this.next().children('.timestamp')
-                        .prop('disabled', !$this.find('input').prop('checked'));
+                    if ($checkbox.prop('checked')) {
+                        now = new Date();
+                        $timestamp
+                            .val(now.getFullYear() + '-' + now.getUTCMonth() + '-' + now.getDate() + ' ' + now.getHours() + ':' + now.getMinutes())
+                            .prop('disabled', false);
+                    } else {
+                        $timestamp.val('').prop('disabled', true);
+                    }
                 });
 
             // Focus the first field so users can get scrobbling fast
@@ -79,7 +88,12 @@
             var album  = $(".album", fieldset).val();
             var timestamp = $(".timestamp", fieldset);
 
-            timestamp = timestamp.is(":disabled") ? '' : timestamp.val();
+            if (timestamp.is(':enabled')) {
+                timestamp = new Date(timestamp.val());
+                timestamp = timestamp ? timestamp.toUTCString() : '';
+            } else {
+                timestamp = '';
+            }
 
             if (artist.trim() !== '' && track.trim() !== '') {
                 return {

--- a/src/views/manual_scrobble.twig
+++ b/src/views/manual_scrobble.twig
@@ -37,7 +37,7 @@
                         </label>
                     </div>
                     <div class="col-xs-9 col-sm-8">
-                        <input class="form-control timestamp" type="text" name="timestamp[]" value="{{ 'now'|date('Y-m-d H:i') }}" aria-label="Date" placeholder="YYYY-MM-DD HH:MM" pattern="\d{4}-?\d{2}-?\d{2} \d{2}:\d{2}" disabled/>
+                        <input class="form-control timestamp" type="text" name="timestamp[]" aria-label="Date" placeholder="YYYY-MM-DD HH:MM" pattern="\d{4}-?\d{1,2}-?\d{2} \d{1,2}:\d{2}" disabled/>
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
- Modified js to send the datetime in UTC and set the current time client-side
- Added default timezone in php 
- Fixed date input validation pattern in form

As it says in http://www.lastfm.es/api/show/track.scrobble:
> ```timestamp[i]``` (Required) : The time the track started playing, in UNIX timestamp format (integer number of seconds since 00:00:00, January 1st 1970 UTC). This must be in the UTC time zone.
