### PR TITLE
fix grunt dependency, replace grunt-concat by grant-contrib-concat

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "grunt-contrib-uglify": "*",
         "grunt-contrib-watch": "*",
         "grunt-contrib-sass": "*",
-        "grunt-concat": "*",
+        "grunt-contrib-concat": "*",
         "grunt-combine-media-queries": "*",
         "grunt-hashres": "*",
         "grunt-htmlclean": "*",


### PR DESCRIPTION
with grunt-concat it gives the following error:

```
Running "concat:js" (concat) task
Verifying property concat.js exists in config...ERROR
>> Unable to process task.
Warning: Required config property "concat.js" missing. Use --force to continue.

Aborted due to warnings.

shell returned 3
```

My commit solves my problem. But, I'm not sure if this have something to do with my environment.