### PR TITLE
Improve Polish translation

### DIFF
--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -1,6 +1,6 @@
 {
   "scrobble": "Scrobbluj",
-  "getScrobbling": "Zacznij Scrobblować",
+  "getScrobbling": "Zacznij scrobblować",
   "loading": "Ładowanie...",
   "artist": "Wykonawca",
   "song": "Utwór",
@@ -64,6 +64,6 @@
   "errors": {
     "lastfmRejected": "Last.fm odrzuciło ten scrobble.",
     "unexpectedResponse": "Nieoczekiwana odpowiedź.",
-    "apiCallFailed": "Połączenie z API przerwane."
+    "apiCallFailed": "Wywołanie API zakończone niepowodzeniem."
   }
 }


### PR DESCRIPTION
- Verbs start with small letter in the Polish language
- Contextualized translation of _apiCallFailed_ [(source)](https://www.linguee.com/english-polish/translation/api+call.html)