### PR TITLE
Fix cancel text portuguese translation

### DIFF
--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -65,7 +65,7 @@
     "specialThanks": "Agradecimentos especiais a todos os doadores, tradutores e <1>aos contribuidores</1>"
   },
   "settings": "Configurações",
-  "cancel": "Calendário",
+  "cancel": "Cancelar",
   "dates": {
     "format": {
       "short": "MMM do"


### PR DESCRIPTION
Just a simple fix changing translation of "cancel" text in portuguese.

<img width="522" alt="image" src="https://github.com/elamperti/OpenWebScrobbler/assets/21269337/be91bead-add9-42f6-b385-32a9a5e05bf4">
