### PR TITLE
Remove old translation

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -8,7 +8,6 @@
   "album": "الألبوم",
   "scrobbleFromAlbum": "سجل الألبومات",
   "scrobbleAlbum": "سجل الألبوم",
-  "album_plural": "الألبومات",
   "goBack": "تراجع",
   "topAlbumsBy": "الالبومات بواسطة {{nameOfArtist}}",
   "noAlbumsFound": "لم يتم العثور على ألبومات ل <1>{{albumOrArtist}}</1>\n",

--- a/public/locales/ast.json
+++ b/public/locales/ast.json
@@ -8,7 +8,6 @@
   "album": "Álbum",
   "scrobbleFromAlbum": "Scrobbliar álbumes",
   "scrobbleAlbum": "Scrobbliar álbum",
-  "album_plural": "Álbumes",
   "goBack": "Tornar",
   "topAlbumsBy": "Álbumes de {{nameOfArtist}}",
   "noAlbumsFound": "Nun s'atopó dengún álbum pa <1>{{albumOrArtist}}</1>",

--- a/public/locales/bg.json
+++ b/public/locales/bg.json
@@ -8,7 +8,6 @@
   "album": "Албум",
   "scrobbleFromAlbum": "Скробълни от албум",
   "scrobbleAlbum": "Скробълни албум",
-  "album_plural": "Албуми",
   "goBack": "Назад",
   "topAlbumsBy": "Албуми от {{nameOfArtist}}",
   "noAlbumsFound": "Няма намерени албуми за <1>{{albumOrArtist}}</1>",

--- a/public/locales/ca.json
+++ b/public/locales/ca.json
@@ -8,7 +8,6 @@
   "album": "Àlbum",
   "scrobbleFromAlbum": "Envia àlbums",
   "scrobbleAlbum": "Envia l’àlbum",
-  "album_plural": "Àlbums",
   "goBack": "Torna enrere",
   "topAlbumsBy": "Àlbums per {{nameOfArtist}}",
   "noAlbumsFound": "No s’ha trobat cap àlbum per <1>{{albumOrArtist}}</1>",

--- a/public/locales/da.json
+++ b/public/locales/da.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobbl albummer",
   "scrobbleAlbum": "Scrobbl album",
-  "album_plural": "Albummer",
   "goBack": "Gå tilbage",
   "topAlbumsBy": "Albummer af {{nameOfArtist}}",
   "noAlbumsFound": "Ingen albummer fundet for <1>{{albumOrArtist}}</1>",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobble Alben",
   "scrobbleAlbum": "Scrobble Album",
-  "album_plural": "Alben",
   "goBack": "Zurück",
   "topAlbumsBy": "Alben von {{nameOfArtist}}",
   "noAlbumsFound": "Keine Alben gefunden für <1>{{albumOrArtist}}</1>",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -8,7 +8,6 @@
   "album": "Άλμπουμ",
   "scrobbleFromAlbum": "Scrobble albums",
   "scrobbleAlbum": "Scrobble album",
-  "album_plural": "Albums",
   "goBack": "Go back",
   "topAlbumsBy": "Albums by {{nameOfArtist}}",
   "noAlbumsFound": "No albums found for <1>{{albumOrArtist}}</1>",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobble albums",
   "scrobbleAlbum": "Scrobble album",
-  "album_plural": "Albums",
   "goBack": "Go back",
   "topAlbumsBy": "Albums by {{nameOfArtist}}",
   "noAlbumsFound": "No albums found for <1>{{albumOrArtist}}</1>",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -8,7 +8,6 @@
   "album": "Álbum",
   "scrobbleFromAlbum": "Scrobblear álbumes",
   "scrobbleAlbum": "Scrobblear álbum",
-  "album_plural": "Álbumes",
   "goBack": "Volver",
   "topAlbumsBy": "Álbumes de {{nameOfArtist}}",
   "noAlbumsFound": "No se encontraron álbumes para <1>{{albumOrArtist}}</1>",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobbler des albums",
   "scrobbleAlbum": "Scrobbler l'album",
-  "album_plural": "Albums",
   "goBack": "Retour",
   "topAlbumsBy": "Albums par {{nameOfArtist}}",
   "noAlbumsFound": "Pas d'album trouvé pour <1>{{albumOrArtist}}</1>",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobbla dall'album",
   "scrobbleAlbum": "Scrobbla album",
-  "album_plural": "Album",
   "goBack": "Indietro",
   "topAlbumsBy": "Album di {{nameOfArtist}}",
   "noAlbumsFound": "Nessun album trovato per <1>{{albumOrArtist}}</1>",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Scrobbel van album",
   "scrobbleAlbum": "Scrobbel album",
-  "album_plural": "Albums",
   "goBack": "Terug",
   "topAlbumsBy": "Albums by {{nameOfArtist}}",
   "noAlbumsFound": "No albums found for <1>{{albumOrArtist}}</1>",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -8,7 +8,6 @@
   "album": "Płyta",
   "scrobbleFromAlbum": "Scrobbluj z albumów",
   "scrobbleAlbum": "Scrobbluj album",
-  "album_plural": "Albumy",
   "goBack": "Wróć",
   "topAlbumsBy": "Albumy autorstwa {{nameOfArtist}}",
   "noAlbumsFound": "Nie znaleziono albumów dla <1>{{albumOrArtist}}</1>",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -8,7 +8,6 @@
   "album": "Álbum",
   "scrobbleFromAlbum": "Fazer scrobble de álbuns",
   "scrobbleAlbum": "Fazer scrobble do álbum",
-  "album_plural": "Álbuns",
   "goBack": "Voltar",
   "topAlbumsBy": "Álbuns por {{nameOfArtist}}",
   "noAlbumsFound": "Nenhum álbum encontrado para <1>{{albumOrArtist}}</1>",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -8,7 +8,6 @@
   "album": "Альбом",
   "scrobbleFromAlbum": "Скробблинг альбомов",
   "scrobbleAlbum": "Скробблить альбом",
-  "album_plural": "Альбом",
   "goBack": "Назад",
   "topAlbumsBy": "Популярные альбомы {{nameOfArtist}}",
   "noAlbumsFound": "Не найдено альбомов, по запросу <1>{{albumOrArtist}}</1>",

--- a/public/locales/sr.json
+++ b/public/locales/sr.json
@@ -8,7 +8,6 @@
   "album": "Album",
   "scrobbleFromAlbum": "Skrobluj albume",
   "scrobbleAlbum": "Skrobluj album",
-  "album_plural": "Albumi",
   "goBack": "Idi nazad",
   "topAlbumsBy": "Albumi {{nameOfArtist}}",
   "noAlbumsFound": "Nisu pronađeni albumi za <1>{{albumOrArtist}}</1>",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -8,7 +8,6 @@
   "album": "Albüm",
   "scrobbleFromAlbum": "Albüm skropla",
   "scrobbleAlbum": "Albüm skropla",
-  "album_plural": "Albümler",
   "goBack": "Geri dön",
   "topAlbumsBy": "{{nameOfArtist}} adlı sanatçıdan albümler",
   "noAlbumsFound": "<1>{{albumOrArtist}}</1> aramasıyla eşleşen bir albüm yok",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -8,7 +8,6 @@
   "album": "Альбом",
   "scrobbleFromAlbum": "Скробблінг альбомів",
   "scrobbleAlbum": "Скробблити альбом",
-  "album_plural": "Альбоми",
   "goBack": "Назад",
   "topAlbumsBy": "Найкращі альбоми {{nameOfArtist}}",
   "noAlbumsFound": "Не знайдено альбомів, за запитом <1>{{albumOrArtist}}</1>",

--- a/public/locales/zh-Hans.json
+++ b/public/locales/zh-Hans.json
@@ -8,7 +8,6 @@
   "album": "专辑",
   "scrobbleFromAlbum": "记录专辑",
   "scrobbleAlbum": "记录专辑",
-  "album_plural": "专辑",
   "goBack": "撤回",
   "topAlbumsBy": "{{nameOfArtist}} 的专辑",
   "noAlbumsFound": "没有找到<1>{{albumOrArtist}}</1>的专辑",


### PR DESCRIPTION
I saw a wrongly formatted id for a translation, and then I noticed that it is not even in use anymore, then I removed it.