### PR TITLE
format album duration properly on Scrobble Album page

### DIFF
--- a/src/components/ScrobbleItem.tsx
+++ b/src/components/ScrobbleItem.tsx
@@ -168,7 +168,7 @@ export default function ScrobbleItem({
     >
       {scrobble.timestamp && <FontAwesomeIcon className={`${compact ? 'me-2' : 'ms-2'}`} icon={faClock} />}
       {scrobble.timestamp && formatScrobbleTimestamp(scrobble.timestamp, settings?.use12Hours)}
-      {!scrobble.timestamp && (scrobble.duration > 0) && formatDuration(scrobble.duration)}
+      {!scrobble.timestamp && scrobble.duration > 0 && formatDuration(scrobble.duration)}
     </small>
   );
 

--- a/src/components/ScrobbleItem.tsx
+++ b/src/components/ScrobbleItem.tsx
@@ -5,10 +5,6 @@ import { get } from 'lodash-es';
 
 import { enqueueScrobble } from 'store/actions/scrobbleActions';
 
-import format from 'date-fns/format';
-import isToday from 'date-fns/isToday';
-import getYear from 'date-fns/getYear';
-
 import { Button, Input, Dropdown, DropdownToggle, DropdownMenu, DropdownItem, FormGroup, Label } from 'reactstrap';
 import { useState } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
@@ -31,6 +27,7 @@ import type { Scrobble } from 'utils/types/scrobble';
 
 import './ScrobbleItem.css';
 import { useSettings } from 'hooks/useSettings';
+import { formatDuration, formatScrobbleTimestamp } from 'utils/datetime';
 
 interface ScrobbleItemProps {
   scrobble: Scrobble;
@@ -110,8 +107,6 @@ export default function ScrobbleItem({
   let songInfo;
   let songFullTitle;
   let statusIcon;
-  let theTimestamp;
-  let timestampFormat = '';
 
   if (noCover || compact) {
     albumArt = null;
@@ -165,28 +160,6 @@ export default function ScrobbleItem({
     }
   }
 
-  if (scrobble.timestamp) {
-    const scrobbleDate = new Date(scrobble.timestamp);
-    if (!isToday(scrobbleDate)) {
-      timestampFormat = settings?.use12Hours ? 'M/d' : 'd/MM';
-      if (getYear(scrobbleDate) < getYear(new Date())) {
-        timestampFormat += '/yyyy';
-      }
-      timestampFormat += ' ';
-    }
-    timestampFormat += settings?.use12Hours ? 'hh:mm a' : 'HH:mm';
-    theTimestamp = format(scrobbleDate, timestampFormat);
-  } else {
-    if (scrobble.duration > 0) {
-      // Yes, there are songs over one hour. Is it worth making this more complex for those? (no, it isn't)
-      const minutes = Math.floor(scrobble.duration / 60);
-      const seconds = `0${scrobble.duration % 60}`.slice(-2);
-      theTimestamp = `${minutes}:${seconds}`;
-    } else {
-      theTimestamp = '';
-    }
-  }
-
   const timeOrDuration = (
     <small
       className={`text-end timestamp d-flex align-items-center ${compact ? 'flex-row' : 'flex-row-reverse'} ${
@@ -194,7 +167,8 @@ export default function ScrobbleItem({
       }`}
     >
       {scrobble.timestamp && <FontAwesomeIcon className={`${compact ? 'me-2' : 'ms-2'}`} icon={faClock} />}
-      {theTimestamp}
+      {scrobble.timestamp && formatScrobbleTimestamp(scrobble.timestamp, settings?.use12Hours)}
+      {!scrobble.timestamp && (scrobble.duration > 0) && formatDuration(scrobble.duration)}
     </small>
   );
 

--- a/src/domains/scrobbleAlbum/partials/Tracklist.tsx
+++ b/src/domains/scrobbleAlbum/partials/Tracklist.tsx
@@ -23,7 +23,7 @@ import type { Album, DiscogsAlbum } from 'utils/types/album';
 import type { Scrobble } from 'utils/types/scrobble';
 import type { Track } from 'utils/types/track';
 
-import { formatDuration } from 'utils/datetime'
+import { formatDuration } from 'utils/datetime';
 
 const DateTimePicker = lazyWithPreload(() => import('components/DateTimePicker'));
 

--- a/src/domains/scrobbleAlbum/partials/Tracklist.tsx
+++ b/src/domains/scrobbleAlbum/partials/Tracklist.tsx
@@ -23,18 +23,9 @@ import type { Album, DiscogsAlbum } from 'utils/types/album';
 import type { Scrobble } from 'utils/types/scrobble';
 import type { Track } from 'utils/types/track';
 
-const DateTimePicker = lazyWithPreload(() => import('components/DateTimePicker'));
+import { formatDuration } from 'utils/datetime'
 
-function formatDuration(totalSeconds: number) {
-  const datetime = addSeconds(new Date(0), totalSeconds);
-  const h = datetime.getUTCHours();
-  const m = datetime.getUTCMinutes();
-  const s = datetime.getUTCSeconds();
-  
-  const mm = (m < 10) ? ("0" + m) : m.toString();
-  const ss = (s < 10) ? ("0" + s) : s.toString();
-  return (h > 0) ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
-}
+const DateTimePicker = lazyWithPreload(() => import('components/DateTimePicker'));
 
 // ToDo: refactor this component completely.
 // It's too complex and carries several blocks from old code.

--- a/src/domains/scrobbleAlbum/partials/Tracklist.tsx
+++ b/src/domains/scrobbleAlbum/partials/Tracklist.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import ReactGA from 'react-ga-neo';
 import addSeconds from 'date-fns/addSeconds';
 import subSeconds from 'date-fns/subSeconds';
-import format from 'date-fns/format';
 
 import { Alert, Badge, Button, FormGroup, Label, Input } from 'reactstrap';
 import { faShoppingCart, faStopwatch, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
@@ -26,6 +25,17 @@ import type { Track } from 'utils/types/track';
 
 const DateTimePicker = lazyWithPreload(() => import('components/DateTimePicker'));
 
+function formatDuration(totalSeconds: number) {
+  const datetime = addSeconds(new Date(0), totalSeconds);
+  const h = datetime.getUTCHours();
+  const m = datetime.getUTCMinutes();
+  const s = datetime.getUTCSeconds();
+  
+  const mm = (m < 10) ? ("0" + m) : m.toString();
+  const ss = (s < 10) ? ("0" + s) : s.toString();
+  return (h > 0) ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
 // ToDo: refactor this component completely.
 // It's too complex and carries several blocks from old code.
 export default function Tracklist({ albumInfo, tracks }: { albumInfo: Album | null; tracks: Track[] | Scrobble[] }) {
@@ -42,7 +52,6 @@ export default function Tracklist({ albumInfo, tracks }: { albumInfo: Album | nu
   const [totalDuration, setTotalDuration] = useState(0);
   const albumHasTracks = tracks && tracks.length > 0;
   const hasAlbumInfo = !!albumInfo && Object.keys(albumInfo).length > 0;
-  const durationFormat = totalDuration > 3600 ? 'H:mm:ss' : 'mm:ss';
 
   useEffect(() => {
     let newDuration = 0;
@@ -155,11 +164,7 @@ export default function Tracklist({ albumInfo, tracks }: { albumInfo: Album | nu
               {tracks.length > 0 && (
                 <div className="album-heading-duration">
                   <FontAwesomeIcon icon={faStopwatch} className="me-2" color="var(--bs-gray)" />
-                  {totalDuration ? (
-                    format(addSeconds(new Date(0), totalDuration), durationFormat)
-                  ) : (
-                    <Trans i18nKey="unknown">Unknown</Trans>
-                  )}
+                  {totalDuration ? formatDuration(totalDuration) : <Trans i18nKey="unknown">Unknown</Trans>}
                 </div>
               )}
             </div>

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -1,0 +1,12 @@
+import { formatDuration } from './datetime';
+
+describe('`formatDuration` helper', () => {
+  it('is correct', () => {
+    expect(formatDuration(45)).toEqual('0:45');
+    expect(formatDuration(150)).toEqual('2:30');
+    expect(formatDuration(187)).toEqual('3:07');
+    expect(formatDuration(777)).toEqual('12:57');
+    expect(formatDuration(3801)).toEqual('1:03:21');
+    expect(formatDuration(4202)).toEqual('1:10:02');
+  });
+});

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,29 @@
+import format from 'date-fns/format';
+import isToday from 'date-fns/isToday';
+import getYear from 'date-fns/getYear';
+
+function zeroPad(secondsOrMinutes: number): string {
+  return (secondsOrMinutes < 10) ? ("0" + secondsOrMinutes) : secondsOrMinutes.toString();
+}
+
+export function formatDuration(totalSeconds: number): string {
+  const datetime = new Date(totalSeconds * 1000);
+  const h = datetime.getUTCHours();
+  const m = datetime.getUTCMinutes();
+  const s = datetime.getUTCSeconds();
+  return (h > 0) ? `${h}:${zeroPad(m)}:${zeroPad(s)}` : `${m}:${zeroPad(s)}`;
+}
+
+export function formatScrobbleTimestamp(timestamp: Date, use12Hours: boolean): string {
+  let timestampFormat = '';
+  if (!isToday(timestamp)) {
+    timestampFormat = use12Hours ? 'M/d' : 'd/MM';
+    if (getYear(timestamp) < getYear(new Date())) {
+      timestampFormat += '/yyyy';
+    }
+    timestampFormat += ' ';
+  }
+  timestampFormat += use12Hours ? 'hh:mm a' : 'HH:mm';
+  return format(timestamp, timestampFormat);
+}
+  

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -3,7 +3,7 @@ import isToday from 'date-fns/isToday';
 import getYear from 'date-fns/getYear';
 
 function zeroPad(secondsOrMinutes: number): string {
-  return (secondsOrMinutes < 10) ? ("0" + secondsOrMinutes) : secondsOrMinutes.toString();
+  return (secondsOrMinutes < 10) ? ('0' + secondsOrMinutes) : secondsOrMinutes.toString();
 }
 
 export function formatDuration(totalSeconds: number): string {
@@ -26,4 +26,3 @@ export function formatScrobbleTimestamp(timestamp: Date, use12Hours: boolean): s
   timestampFormat += use12Hours ? 'hh:mm a' : 'HH:mm';
   return format(timestamp, timestampFormat);
 }
-  

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -3,7 +3,7 @@ import isToday from 'date-fns/isToday';
 import getYear from 'date-fns/getYear';
 
 function zeroPad(secondsOrMinutes: number): string {
-  return (secondsOrMinutes < 10) ? ('0' + secondsOrMinutes) : secondsOrMinutes.toString();
+  return secondsOrMinutes < 10 ? '0' + secondsOrMinutes : secondsOrMinutes.toString();
 }
 
 export function formatDuration(totalSeconds: number): string {
@@ -11,7 +11,7 @@ export function formatDuration(totalSeconds: number): string {
   const h = datetime.getUTCHours();
   const m = datetime.getUTCMinutes();
   const s = datetime.getUTCSeconds();
-  return (h > 0) ? `${h}:${zeroPad(m)}:${zeroPad(s)}` : `${m}:${zeroPad(s)}`;
+  return h > 0 ? `${h}:${zeroPad(m)}:${zeroPad(s)}` : `${m}:${zeroPad(s)}`;
 }
 
 export function formatScrobbleTimestamp(timestamp: Date, use12Hours: boolean): string {


### PR DESCRIPTION
Currently the total duration on Scrobble Album page is rendered incorrectly if the album is longer than 1 hour and the browser in a different timezone than UTC.
[Screenshot: it shows duration to be 3 hours instead of 1, because I'm in UTC+2](https://github.com/user-attachments/assets/2461c1c3-04e5-4d5c-ba53-909b650230f4) 

This is happening because the code uses `format()` from `date-fns`, and there is no easy way to make it timezone-agnostic for _H:mm:ss_  format.

This commit fixes that.

