### PR TITLE
Auto-fill album for artist and track (closes #88)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -160,5 +160,7 @@
   "connect": "Connect",
   "General settings title": {
     "general": "General"
-  }
+  },
+  "suggestAlbum": "Suggest album name",
+  "suggestAlbumInvalidForm": "Fill artist and track fields for album suggestions"
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -161,6 +161,6 @@
   "General settings title": {
     "general": "General"
   },
-  "suggestAlbum": "Suggest album name",
-  "suggestAlbumInvalidForm": "Fill artist and track fields for album suggestions"
+  "autoFillAlbum": "Fill album name from last.fm",
+  "autoFillAlbumInvalidForm": "Enter artist and track for album auto-fill"
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -161,6 +161,6 @@
   "General settings title": {
     "general": "General"
   },
-  "suggestAlbum": "Предложить альбом",
-  "suggestAlbumInvalidForm": "Заполните имя исполнителя и трек, чтобы предложить альбом"
+  "autoFillAlbum": "Заполнить альбом с last.fm",
+  "autoFillAlbumInvalidForm": "Введите имя исполнителя и трек, чтобы автозаполнить альбом"
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -160,5 +160,7 @@
   "connect": "Connect",
   "General settings title": {
     "general": "General"
-  }
+  },
+  "suggestAlbum": "Предложить альбом",
+  "suggestAlbumInvalidForm": "Заполните имя исполнителя и трек, чтобы предложить альбом"
 }

--- a/src/domains/scrobbleSong/SongForm.css
+++ b/src/domains/scrobbleSong/SongForm.css
@@ -29,8 +29,8 @@ input.autofill-success {
 }
 
 input.autofill-fail {
-  box-shadow: inset 0 0 0.4em #f00;
-  border-color: #f00;
+  box-shadow: inset 0 0 0.4em var(--bs-red);
+  border-color: var(--bs-danger-border-subtle);
 }
 
 .lock-button {
@@ -104,12 +104,22 @@ input.autofill-fail {
 }
 
 @keyframes shake {
-  0% { transform: translateX(0) }
-  25% { transform: translateX(4px) }
-  50% { transform: translateX(-4px) }
-  75% { transform: translateX(4px) }
-  100% { transform: translateX(0) }
- }
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(4px);
+  }
+  50% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
 
 .autofill-fail {
   animation: shake 0.18s 2;

--- a/src/domains/scrobbleSong/SongForm.css
+++ b/src/domains/scrobbleSong/SongForm.css
@@ -19,6 +19,20 @@ input.hasLock {
   padding-right: 2em;
 }
 
+input.hasLockAndSuggestButton {
+  padding-right: 4em;
+}
+
+input.suggest-success {
+  box-shadow: inset 0 0 0.4em #5bc0de;
+  border-color: #5bc0de;
+}
+
+input.suggest-fail {
+  box-shadow: inset 0 0 0.4em #f00;
+  border-color: #f00;
+}
+
 .lock-button {
   position: relative;
   height: 1.6rem;
@@ -87,4 +101,16 @@ input.hasLock {
 
 .SongForm-PasteAlert {
   cursor: pointer;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0) }
+  25% { transform: translateX(4px) }
+  50% { transform: translateX(-4px) }
+  75% { transform: translateX(4px) }
+  100% { transform: translateX(0) }
+ }
+
+.suggest-fail {
+  animation: shake 0.18s 2;
 }

--- a/src/domains/scrobbleSong/SongForm.css
+++ b/src/domains/scrobbleSong/SongForm.css
@@ -15,20 +15,20 @@ Label.required::after {
   width: calc(100% + 15px);
 }
 
-input.hasLock {
+input.has-button {
   padding-right: 2em;
 }
 
-input.hasLockAndSuggestButton {
+input.has-two-buttons {
   padding-right: 4em;
 }
 
-input.suggest-success {
+input.autofill-success {
   box-shadow: inset 0 0 0.4em #5bc0de;
   border-color: #5bc0de;
 }
 
-input.suggest-fail {
+input.autofill-fail {
   box-shadow: inset 0 0 0.4em #f00;
   border-color: #f00;
 }
@@ -43,7 +43,7 @@ input.suggest-fail {
   cursor: pointer;
 }
 
-.suggest-album-button {
+.autofill-button {
   position: relative;
   height: 1.6rem;
   top: -3.4rem;
@@ -111,6 +111,6 @@ input.suggest-fail {
   100% { transform: translateX(0) }
  }
 
-.suggest-fail {
+.autofill-fail {
   animation: shake 0.18s 2;
 }

--- a/src/domains/scrobbleSong/SongForm.css
+++ b/src/domains/scrobbleSong/SongForm.css
@@ -29,13 +29,33 @@ input.hasLock {
   cursor: pointer;
 }
 
+.suggest-album-button {
+  position: relative;
+  height: 1.6rem;
+  top: -3.4rem;
+  right: 1.75rem;
+  margin-left: calc(100% - 1.5rem);
+  padding: 0.1rem 0.4rem 0.1rem;
+  cursor: pointer;
+}
+
 .input-with-lock {
   max-height: 1rem;
 }
 
-.fa-thumbtack {
+.fa-thumbtack,
+.fa-wand-magic-sparkles {
   color: #aaaaaa;
   transition: 0.2s;
+}
+
+.fa-thumbtack:hover,
+.fa-wand-magic-sparkles:hover {
+  color: #777777;
+}
+
+.fa-wand-magic-sparkles.disabled {
+  color: #cccccc;
 }
 
 .fa-thumbtack.active {

--- a/src/domains/scrobbleSong/SongForm.tsx
+++ b/src/domains/scrobbleSong/SongForm.tsx
@@ -416,7 +416,10 @@ export function SongForm() {
             data-cy="SongForm-autofill-button"
             onClick={autoFillAlbum}
           >
-            <FontAwesomeIcon icon={faWandMagicSparkles} className={formIsValid ? '' : 'disabled'} />
+            <FontAwesomeIcon
+              icon={faWandMagicSparkles}
+              className={formIsValid || albumAutoFillStatus === AutoFillStatus.Fail ? '' : 'disabled'}
+            />
           </div>
           <Tooltip target="autofill-album">
             {formIsValid ? (

--- a/src/domains/scrobbleSong/SongForm.tsx
+++ b/src/domains/scrobbleSong/SongForm.tsx
@@ -33,10 +33,10 @@ const Tooltip = lazyWithPreload(() => import('components/Tooltip'));
 const reAutoPasteSplitting = / - | ?[–—] ?/;
 const controlOrder = ['artist', 'title', 'album']; // Used for arrow navigation
 
-enum SuggestStatus {
+enum AutoFillStatus {
   Idle = "",
-  Success = "suggest-success",
-  Fail = "suggest-fail",
+  Success = "autofill-success",
+  Fail = "autofill-fail",
 }
 
 export function extractArtistTitle(text: string, reverse = false) {
@@ -65,7 +65,7 @@ export function SongForm() {
   const [timestamp, setTimestamp] = useState(new Date());
   const [title, setTitle] = useState('');
   const [isCustomDate, setIsCustomDate] = useState(false);
-  const [albumSuggestStatus, setAlbumSuggestStatus] = useState(SuggestStatus.Idle);
+  const [albumAutoFillStatus, setalbumAutoFillStatus] = useState(AutoFillStatus.Idle);
 
   const dispatch = useDispatch();
   const { isLoading: settingsLoading, settings } = useSettings();
@@ -272,7 +272,7 @@ export function SongForm() {
     setFormValid(artist.trim().length > 0 && title.trim().length > 0);
   };
 
-  const suggestAlbumName = async () => {
+  const autoFillAlbum = async () => {
     if (!formIsValid) {
       return;
     }
@@ -280,12 +280,12 @@ export function SongForm() {
     const suggestedAlbum = get(info, 'album.title');
     
     if (suggestedAlbum === undefined) {
-      setAlbumSuggestStatus(SuggestStatus.Fail);
+      setalbumAutoFillStatus(AutoFillStatus.Fail);
     } else {
-      setAlbumSuggestStatus(SuggestStatus.Success);
+      setalbumAutoFillStatus(AutoFillStatus.Success);
       setAlbum(suggestedAlbum);
     }
-    setTimeout(() => setAlbumSuggestStatus(SuggestStatus.Idle), 1200);
+    setTimeout(() => setalbumAutoFillStatus(AutoFillStatus.Idle), 1200);
   };
 
   return (
@@ -301,7 +301,7 @@ export function SongForm() {
             name="artist"
             id="artist"
             tabIndex={1}
-            className="hasLock"
+            className="has-button"
             data-cy="SongForm-artist"
             value={artist}
             onChange={(e) => setArtist((e.target as HTMLInputElement).value)}
@@ -363,7 +363,7 @@ export function SongForm() {
             name="album"
             id="album"
             tabIndex={3}
-            className={'hasLockAndSuggestButton ' + albumSuggestStatus}
+            className={'has-two-buttons ' + albumAutoFillStatus}
             data-cy="SongForm-album"
             value={album}
             onChange={(e) => setAlbum((e.target as HTMLInputElement).value)}
@@ -371,7 +371,7 @@ export function SongForm() {
           />
 
           <div
-            className={'lock-button rounded ' + albumSuggestStatus}
+            className={'lock-button rounded ' + albumAutoFillStatus}
             id="lock-album"
             data-cy="SongForm-album-lock"
             onClick={toggleLock('album')}
@@ -383,18 +383,18 @@ export function SongForm() {
           </Tooltip>
 
           <div
-            className={'suggest-album-button rounded ' + albumSuggestStatus}
-            id="suggest-album"
-            data-cy="SongForm-suggest-album-button"
-            onClick={suggestAlbumName}
+            className={'autofill-button rounded ' + albumAutoFillStatus}
+            id="autofill-album"
+            data-cy="SongForm-autofill-button"
+            onClick={autoFillAlbum}
           >
             <FontAwesomeIcon icon={faWandMagicSparkles} className={formIsValid ? '' : 'disabled'} />
           </div>
-          <Tooltip target="suggest-album">
+          <Tooltip target="autofill-album">
             {formIsValid ? (
-              <Trans i18nKey="suggestAlbum">Suggest album name</Trans>
+              <Trans i18nKey="autoFillAlbum">Fill album name from last.fm</Trans>
             ) : (
-              <Trans i18nKey="suggestAlbumInvalidForm">Fill artist and track fields for album suggestions</Trans>
+              <Trans i18nKey="autoFillAlbumInvalidForm">Enter artist and track for album auto-fill</Trans>
             )}
           </Tooltip>
         </div>
@@ -410,7 +410,7 @@ export function SongForm() {
             name="albumArtist"
             id="albumArtist"
             tabIndex={3}
-            className="hasLock"
+            className="has-button"
             data-cy="SongForm-albumArtist"
             value={albumArtist}
             onChange={(e) => setAlbumArtist((e.target as HTMLInputElement).value)}

--- a/src/domains/scrobbleSong/SongForm.tsx
+++ b/src/domains/scrobbleSong/SongForm.tsx
@@ -10,7 +10,7 @@ import addDays from 'date-fns/addDays';
 import { Button, ButtonGroup, Form, FormGroup, Input, Label } from 'reactstrap';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faThumbtack, faExchangeAlt, faHeart } from '@fortawesome/free-solid-svg-icons';
+import { faThumbtack, faExchangeAlt, faHeart, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons';
 import { faLightbulb } from '@fortawesome/free-regular-svg-icons';
 
 import { useSettings } from 'hooks/useSettings';
@@ -23,6 +23,9 @@ import { DEFAULT_SONG_DURATION } from 'Constants';
 import './SongForm.css';
 
 import type { Scrobble } from 'utils/types/scrobble';
+
+import { trackGetInfo } from 'utils/clients/lastfm/methods/trackGetInfo';
+import { get } from 'lodash-es';
 
 const DateTimePicker = lazyWithPreload(() => import('components/DateTimePicker'));
 const Tooltip = lazyWithPreload(() => import('components/Tooltip'));
@@ -262,6 +265,17 @@ export function SongForm() {
     setFormValid(artist.trim().length > 0 && title.trim().length > 0);
   };
 
+  const suggestAlbumName = async () => {
+    if (!formIsValid) {
+      return;
+    }
+    const info = await trackGetInfo({ artist: artist, title: title });
+    const suggestedAlbum = get(info, 'album.title');
+    if (suggestedAlbum !== undefined) {
+      setAlbum(suggestedAlbum);
+    }
+  };
+
   return (
     <Form className="SongForm" data-cy="SongForm">
       <FormGroup className="row">
@@ -353,6 +367,22 @@ export function SongForm() {
           </div>
           <Tooltip target="lock-album">
             <Trans i18nKey="lockAlbum">Lock album</Trans>
+          </Tooltip>
+
+          <div
+            className="suggest-album-button rounded"
+            id="suggest-album"
+            data-cy="SongForm-suggest-album-button"
+            onClick={suggestAlbumName}
+          >
+            <FontAwesomeIcon icon={faWandMagicSparkles} className={formIsValid ? '' : 'disabled'} />
+          </div>
+          <Tooltip target="suggest-album">
+            {formIsValid ? (
+              <Trans i18nKey="suggestAlbum">Suggest album name</Trans>
+            ) : (
+              <Trans i18nKey="suggestAlbumInvalidForm">Fill artist and track fields for album suggestions</Trans>
+            )}
           </Tooltip>
         </div>
       </FormGroup>

--- a/src/domains/scrobbleSong/SongForm.tsx
+++ b/src/domains/scrobbleSong/SongForm.tsx
@@ -34,9 +34,9 @@ const reAutoPasteSplitting = / - | ?[–—] ?/;
 const controlOrder = ['artist', 'title', 'album']; // Used for arrow navigation
 
 enum AutoFillStatus {
-  Idle = "",
-  Success = "autofill-success",
-  Fail = "autofill-fail",
+  Idle = '',
+  Success = 'autofill-success',
+  Fail = 'autofill-fail',
 }
 
 export function extractArtistTitle(text: string, reverse = false) {
@@ -276,9 +276,9 @@ export function SongForm() {
     if (!formIsValid) {
       return;
     }
-    const info = await trackGetInfo({ artist: artist, title: title });
+    const info = await trackGetInfo({ artist, title });
     const suggestedAlbum = get(info, 'album.title');
-    
+
     if (suggestedAlbum === undefined) {
       setalbumAutoFillStatus(AutoFillStatus.Fail);
     } else {

--- a/src/utils/clients/lastfm/methods/trackGetInfo.test.ts
+++ b/src/utils/clients/lastfm/methods/trackGetInfo.test.ts
@@ -1,0 +1,37 @@
+import { lastfmAPI } from '../apiClient';
+import { trackGetInfo } from './trackGetInfo';
+
+vi.mock('../apiClient');
+
+describe('Last.fm client: `trackGetInfo` method', () => {
+  it('calls the API to get the track info', async () => {
+    await trackGetInfo({ mbid: '1', artist: 'test-artist', title: 'test' });
+
+    expect(lastfmAPI.get).toHaveBeenCalledWith('', {
+      params: expect.objectContaining({
+        method: 'track.getInfo',
+      }),
+    });
+  });
+
+  it('uses the mbid of the track', async () => {
+    await trackGetInfo({ mbid: '1', artist: 'test-artist', title: 'test' });
+
+    expect(lastfmAPI.get).toHaveBeenCalledWith('', {
+      params: expect.objectContaining({
+        mbid: '1',
+      }),
+    });
+  });
+
+  it('uses the track and artist name in absence of an mbid', async () => {
+    await trackGetInfo({ artist: 'test-artist', title: 'test' });
+
+    expect(lastfmAPI.get).toHaveBeenCalledWith('', {
+      params: expect.objectContaining({
+        artist: 'test-artist',
+        track: 'test',
+      }),
+    });
+  });
+});

--- a/src/utils/clients/lastfm/methods/trackGetInfo.ts
+++ b/src/utils/clients/lastfm/methods/trackGetInfo.ts
@@ -1,0 +1,22 @@
+import { get } from 'lodash-es';
+import { lastfmAPI } from '../apiClient';
+
+export async function trackGetInfo(track: { mbid?: string; artist: string; title: string }) {
+  const searchParams = track.mbid
+    ? {
+        mbid: track.mbid,
+      }
+    : {
+        artist: track.artist,
+        track: track.title,
+      };
+
+  const response = await lastfmAPI.get('', {
+    params: {
+      method: 'track.getInfo',
+      ...searchParams,
+    },
+  });
+
+  return get(response, 'data.track');
+}


### PR DESCRIPTION
The feature uses last.fm API trackGetInfo to retrieve an album name based on track + artist.

To complete this, I'd ask for help with a couple of things:
1) Translation, I added two new tooltips;
2) Creating some animation telling user of success/failure of the operation.

Things to consider: rate-limit last.fm API calls? Delegate to backend?