### PR TITLE
Parse song info from Last.fm url #221

### DIFF
--- a/src/domains/scrobbleSong/SongForm.test.ts
+++ b/src/domains/scrobbleSong/SongForm.test.ts
@@ -1,39 +1,79 @@
 import { extractArtistTitle } from './SongForm';
 
 describe('`extractArtistTitle` helper', () => {
-  it('extracts artist and title from text', () => {
-    const text = 'Artist - Title';
-    const result = extractArtistTitle(text);
-    expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+  describe('`splitArtistTitleFromText` function', () => {
+    it('extracts artist and title from text', () => {
+      const text = 'Artist - Title';
+      const result = extractArtistTitle(text);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
+
+    it('extracts artist and title from text in reverse order', () => {
+      const text = 'Title - Artist';
+      const result = extractArtistTitle(text, true);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
+
+    it('returns null if text does not match pattern', () => {
+      const text = 'Invalid text';
+      const result = extractArtistTitle(text);
+      expect(result).toBeNull();
+    });
+
+    it('works with emdash', () => {
+      const text = 'Artist — Title';
+      const result = extractArtistTitle(text);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
+
+    it('works with endash', () => {
+      const text = 'Artist – Title';
+      const result = extractArtistTitle(text);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
+
+    it('works with emdash even without spaces around it', () => {
+      const text = 'JAY-Z—4:44';
+      const result = extractArtistTitle(text);
+      expect(result).toEqual({ artist: 'JAY-Z', title: '4:44' });
+    });
   });
 
-  it('extracts artist and title from text in reverse order', () => {
-    const text = 'Title - Artist';
-    const result = extractArtistTitle(text, true);
-    expect(result).toEqual({ artist: 'Artist', title: 'Title' });
-  });
+  describe('`parseLastFmUrl` function', () => {
+    it('extracts artist and title from Last.fm URL', () => {
+      const url = 'https://www.last.fm/music/Artist/_/Title';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
 
-  it('returns null if text does not match pattern', () => {
-    const text = 'Invalid text';
-    const result = extractArtistTitle(text);
-    expect(result).toBeNull();
-  });
+    it('extracts artist and title from Last.fm URL with country code', () => {
+      const url = 'https://www.last.fm/pt/music/Artist/_/Title';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
 
-  it('works with emdash', () => {
-    const text = 'Artist — Title';
-    const result = extractArtistTitle(text);
-    expect(result).toEqual({ artist: 'Artist', title: 'Title' });
-  });
+    it('extracts artist and title from Last.fm URL with encoded characters', () => {
+      const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name' });
+    });
 
-  it('works with endash', () => {
-    const text = 'Artist – Title';
-    const result = extractArtistTitle(text);
-    expect(result).toEqual({ artist: 'Artist', title: 'Title' });
-  });
+    it('extracts artist and title from Last.fm URL with encoded characters and special characters', () => {
+      const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name%20(Feat.%20Artist%202)';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name (Feat. Artist 2)' });
+    });
 
-  it('works with emdash even without spaces around it', () => {
-    const text = 'JAY-Z—4:44';
-    const result = extractArtistTitle(text);
-    expect(result).toEqual({ artist: 'JAY-Z', title: '4:44' });
+    it('extracts artist and title from Last.fm URL with encoded characters, special characters and multiple dashes', () => {
+      const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name%20(Feat.%20Artist%202)%20-%20Remix';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name (Feat. Artist 2) - Remix' });
+    });
+
+    it('returns null if URL does not match pattern', () => {
+      const url = 'https://www.last.fm/music/Artist';
+      const result = extractArtistTitle(url);
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/domains/scrobbleSong/SongForm.test.ts
+++ b/src/domains/scrobbleSong/SongForm.test.ts
@@ -1,14 +1,15 @@
 import { extractArtistTitle } from './SongForm';
 
 describe('`extractArtistTitle` helper', () => {
-  describe('`splitArtistTitleFromText` function', () => {
+  describe('from pasted text', () => {
     it('extracts artist and title from text', () => {
       const text = 'Artist - Title';
       const result = extractArtistTitle(text);
       expect(result).toEqual({ artist: 'Artist', title: 'Title' });
     });
 
-    it('extracts artist and title from text in reverse order', () => {
+    it('extracts artist and title reversed', () => {
+      // This is the case where the user pastes into the title field
       const text = 'Title - Artist';
       const result = extractArtistTitle(text, true);
       expect(result).toEqual({ artist: 'Artist', title: 'Title' });
@@ -39,35 +40,65 @@ describe('`extractArtistTitle` helper', () => {
     });
   });
 
-  describe('`parseLastFmUrl` function', () => {
-    it('extracts artist and title from Last.fm URL', () => {
+  describe('from Last.fm URLs', () => {
+    it('extracts artist and title', () => {
       const url = 'https://www.last.fm/music/Artist/_/Title';
       const result = extractArtistTitle(url);
       expect(result).toEqual({ artist: 'Artist', title: 'Title' });
     });
 
-    it('extracts artist and title from Last.fm URL with country code', () => {
+    it('supports a partial URL', () => {
+      const url = 'last.fm/music/Artist/_/Title';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist', title: 'Title' });
+    });
+
+    it('skips country code', () => {
       const url = 'https://www.last.fm/pt/music/Artist/_/Title';
       const result = extractArtistTitle(url);
       expect(result).toEqual({ artist: 'Artist', title: 'Title' });
     });
 
-    it('extracts artist and title from Last.fm URL with encoded characters', () => {
+    it('skips country code in albums', () => {
+      const url = 'https://www.last.fm/fr/music/Artist/Album/';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual(null);
+    });
+
+    it('extracts the album name if present', () => {
+      const url = 'https://www.last.fm/music/Artist/Album/Title';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({ artist: 'Artist', album: 'Album', title: 'Title' });
+    });
+
+    it('handles encoded characters', () => {
       const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name';
       const result = extractArtistTitle(url);
       expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name' });
     });
 
-    it('extracts artist and title from Last.fm URL with encoded characters and special characters', () => {
+    it('extracts artist and title with encoded characters and special characters', () => {
       const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name%20(Feat.%20Artist%202)';
       const result = extractArtistTitle(url);
       expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name (Feat. Artist 2)' });
     });
 
-    it('extracts artist and title from Last.fm URL with encoded characters, special characters and multiple dashes', () => {
-      const url = 'https://www.last.fm/music/Artist%20Name/_/Title%20Name%20(Feat.%20Artist%202)%20-%20Remix';
+    it.skip('supports a double-encoded plus sign', () => {
+      // We shouldn't get cases like this, but I happened to find this one. No use in fixing it for now.
+      const url = 'https://www.last.fm/es/music/Florence+%252B+the+Machine/_/You%27ve+Got+the+Love';
       const result = extractArtistTitle(url);
-      expect(result).toEqual({ artist: 'Artist Name', title: 'Title Name (Feat. Artist 2) - Remix' });
+      expect(result).toEqual({ artist: 'Florence + the Machine', title: "You've Got the Love" });
+    });
+
+    it('handles question marks properly', () => {
+      const url =
+        'https://www.last.fm/es/music/Man%C3%A1/%C2%BFD%C3%B3nde+jugar%C3%A1n+los+ni%C3%B1os%3F/%C2%BFD%C3%B3nde+jugar%C3%A1n+los+ni%C3%B1os%3F';
+      const result = extractArtistTitle(url);
+      expect(result).toEqual({
+        artist: 'Maná',
+        album: '¿Dónde jugarán los niños?',
+        title: '¿Dónde jugarán los niños?',
+      });
     });
 
     it('returns null if URL does not match pattern', () => {

--- a/src/domains/scrobbleSong/SongForm.tsx
+++ b/src/domains/scrobbleSong/SongForm.tsx
@@ -30,7 +30,7 @@ const Tooltip = lazyWithPreload(() => import('components/Tooltip'));
 const reAutoPasteSplitting = / - | ?[–—] ?/;
 const controlOrder = ['artist', 'title', 'album']; // Used for arrow navigation
 
-export function extractArtistTitle(text: string, reverse = false) {
+export function splitArtistTitleFromText(text: string, reverse: boolean) {
   if (reAutoPasteSplitting.test(text)) {
     const result = text.split(reAutoPasteSplitting, 2);
 
@@ -42,6 +42,28 @@ export function extractArtistTitle(text: string, reverse = false) {
   }
 
   return null;
+}
+
+const parseLastFmUrl = (url: string) => {
+  const regex = /^https?:\/\/(www\.)?last\.fm(\/[a-zA-Z]{2})?\/music\/([^/]+)\/_\/([^/]+)$/;
+  const match = url.match(regex);
+
+  if (!match) {
+    return null;
+  }
+
+  const artist = decodeURIComponent(match[3].replace(/\+/g, ' '));
+  const title = decodeURIComponent(match[4].replace(/\+/g, ' '));
+
+  return {
+    artist,
+    title,
+  };
+};
+
+export function extractArtistTitle(text: string, reverse = false) {
+  const parsedText = parseLastFmUrl(text);
+  return parsedText ?? splitArtistTitleFromText(text, reverse);
 }
 
 export function SongForm() {


### PR DESCRIPTION
It closes #221 
When pasting a valid Last.fm URL, it splits the artist and track.

https://github.com/user-attachments/assets/b6d19cf3-60e9-44a1-8ad7-2fdbab589e86

