### PR TITLE
Replace lodash hasIn usages

### DIFF
--- a/src/store/actions/userActions.js
+++ b/src/store/actions/userActions.js
@@ -1,5 +1,3 @@
-import { hasIn } from 'lodash-es';
-
 import { logout } from 'utils/clients/api/methods/logout';
 import history from 'utils/history';
 
@@ -17,7 +15,7 @@ export function logOut(dispatch) {
         history.push('/');
         dispatch(
           createAlert(
-            hasIn(alertObject, 'message')
+            alertObject && 'message' in alertObject
               ? alertObject
               : {
                   type: 'info',

--- a/src/store/reducers/scrobbleReducer.ts
+++ b/src/store/reducers/scrobbleReducer.ts
@@ -1,4 +1,3 @@
-import { hasIn } from 'lodash-es';
 import shortid from 'shortid';
 
 import { scrobble } from 'utils/clients/api/methods/scrobble';
@@ -188,7 +187,7 @@ const scrobbleReducer = (state = initialState, action) => {
       };
 
     case `${SCROBBLE}_FULFILLED`:
-      if (hasIn(action.payload, 'data.scrobbles[@attr]')) {
+      if (action.payload?.data?.scrobbles?.['@attr']) {
         return updateScrobbleProps(state, action.payload.config.headers.scrobbleUUID, {
           scrobbles: castArray(action.payload.data.scrobbles.scrobble),
           // attr: action.payload.scrobbles['@attr'],
@@ -206,7 +205,7 @@ const scrobbleReducer = (state = initialState, action) => {
       }
 
     case `${SCROBBLE}_REJECTED`:
-      if (hasIn(action.payload, 'config.headers.scrobbleUUID')) {
+      if (action.payload?.config?.headers?.scrobbleUUID) {
         return overrideScrobbleProps(state, action.payload.config.headers.scrobbleUUID, {
           status: 'error',
           errorDescription: 'errors.apiCallFailed',
@@ -216,7 +215,7 @@ const scrobbleReducer = (state = initialState, action) => {
 
     case `${SCROBBLE_COVER_SEARCH}_FULFILLED`:
       trackUUID = action.payload.config.params._uuid;
-      if (hasIn(action.payload, 'data.track.album') || hasIn(action.payload, 'data.album')) {
+      if (action.payload?.data?.track?.album || action.payload?.data?.album) {
         albumData = action.payload.data.album || action.payload.data.track.album;
         if (albumData.image) {
           const cover = albumData.image[1]['#text'];

--- a/src/utils/clients/discogs/transformers/tracksResponse.transformer.ts
+++ b/src/utils/clients/discogs/transformers/tracksResponse.transformer.ts
@@ -1,4 +1,3 @@
-import { hasIn } from 'lodash-es';
 import shortid from 'shortid';
 
 import { sanitizeArtistName } from './common/sanitizeArtistName';
@@ -51,7 +50,7 @@ export function tracksTransformer(
         trackNumber: track.position || null,
       } as Track;
 
-      if (hasIn(options, 'cover')) {
+      if (options?.cover) {
         transformedTrack.cover = options.cover;
       }
 

--- a/src/utils/clients/lastfm/transformers/tracksResponse.transformer.ts
+++ b/src/utils/clients/lastfm/transformers/tracksResponse.transformer.ts
@@ -1,4 +1,3 @@
-import { hasIn } from 'lodash-es';
 import shortid from 'shortid';
 
 import { castArray } from 'utils/common';
@@ -26,7 +25,7 @@ export function tracksTransformer(
       trackNumber: track['@attr'] ? parseInt(track['@attr'].rank) : null,
     } as Track;
 
-    if (hasIn(options, 'cover')) {
+    if (options?.cover) {
       transformedTrack.cover = options.cover;
     }
 

--- a/src/utils/clients/lastfm/transformers/userRecentTracks.transformer.ts
+++ b/src/utils/clients/lastfm/transformers/userRecentTracks.transformer.ts
@@ -1,9 +1,7 @@
-import { hasIn } from 'lodash-es';
-
 export function userRecentTracksTransformer(response: any) {
   const tracks = [];
   const rawTrackList = response?.data?.recenttracks?.track ?? [];
-  if (hasIn(response, 'data.recenttracks.track')) {
+  if (response?.data?.recenttracks?.track) {
     for (const item of rawTrackList) {
       if (!item?.['@attr']?.nowplaying) {
         tracks.push({


### PR DESCRIPTION
## Summary
- remove lodash `hasIn` in multiple modules
- use optional chaining or `'in'` operator

## Testing
- `yarn test:unit`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685db9c32080832886ff644373983b2b