### PR TITLE
Don't disable dropdown to toggle between Album Search sources

### DIFF
--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -125,7 +125,6 @@ export default function SearchForm({
               <DropdownToggle
                 caret
                 color="success"
-                className={disableSearch ? styles['fake-disabled'] : ''}
                 data-cy="SearchForm-dropdown-toggle"
               />
               <DropdownMenu data-cy="SearchForm-dropdown-menu">{searchOptions}</DropdownMenu>

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -122,11 +122,7 @@ export default function SearchForm({
           {searchOptions && (
             <UncontrolledDropdown group className="w-100" data-cy="SearchForm-dropdown">
               {searchButton}
-              <DropdownToggle
-                caret
-                color="success"
-                data-cy="SearchForm-dropdown-toggle"
-              />
+              <DropdownToggle caret color="success" data-cy="SearchForm-dropdown-toggle" />
               <DropdownMenu data-cy="SearchForm-dropdown-menu">{searchOptions}</DropdownMenu>
             </UncontrolledDropdown>
           )}


### PR DESCRIPTION
Quality of life impovement: switching between Album Search source type (Last.fm / Discogs) should be allowed even if the search field is empty