### PR TITLE
Add data source switch on album search results page

### DIFF
--- a/cypress/e2e/scrobbleAlbum/scrobble-album-data-source.spec.js
+++ b/cypress/e2e/scrobbleAlbum/scrobble-album-data-source.spec.js
@@ -1,0 +1,123 @@
+describe('Scrobble album data source (SRP)', () => {
+  beforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+
+    cy.intercept('GET', '/api/v2/user.php', { fixture: 'api/v2/user/authenticated.json' }).as('userData');
+    cy.intercept('GET', '/api/v2/settings.php', { fixture: 'api/v2/settings/authenticated.json' });
+
+    // set up both searches to test switching
+
+    cy.intercept('GET', '/api/v2/discogs.php?method=artist.search&type=artist*', {
+      fixture: 'api/v2/discogs/artist.search.meteora.json',
+    }).as('artistSearchDiscogs');
+    cy.intercept('GET', '/api/v2/discogs.php?method=album.search&type=master*', {
+      fixture: 'api/v2/discogs/album.search.meteora.json',
+    }).as('albumSearchDiscogs');
+
+    cy.intercept('GET', 'https://ws.audioscrobbler.com/2.0/*method=artist.search*', {
+      fixture: 'lastfm/artist/search.meteora.json',
+    }).as('artistSearchLastFm');
+    cy.intercept('GET', 'https://ws.audioscrobbler.com/2.0/*method=album.search*', {
+      fixture: 'lastfm/album/search.meteora.json',
+    }).as('albumSearchLastFm');
+  });
+
+  describe('using Discogs', () => {
+    beforeEach(() => {
+      cy.visit('/scrobble/album/search/Meteora?source=discogs');
+      cy.wait('@userData');
+    });
+
+    it('displays dropdown for data sources', () => {
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').should('exist');
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').click();
+      cy.get('[data-cy="DataSourceDropdown-menu"]').children().should('have.length', 2);
+      // check active item matches data source
+      cy.get('[data-cy="DataSourceDropdown-menu"]')
+        .children('button.active')
+        .should('have.text', 'Discogs');
+    });
+
+    it('switches data source to Last.fm', () => {
+      // check initial Discogs results
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .parent()
+        .should('have.attr', 'href')
+        .and('match', /https:\/\/www.discogs.com\/master\/.*/);
+
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').click();
+      cy.get('[data-cy="DataSourceDropdown-menu"]')
+        .find('[data-cy="DataSourceDropdown-item-lastfm"]')
+        .click();
+        
+      // check Last.fm results
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .parent()
+        .should('have.attr', 'href')
+        .and('match', /https:\/\/www.last.fm\/music\/.*\/.*/);
+    });
+
+    it('displays static data source on album view', () => {
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .click();
+
+      cy.location('pathname').should('match', /scrobble\/album\/view/);
+
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').should('not.exist');
+      cy.get('[data-cy="AlbumBreadcrumb-provider"]').should('have.text', 'Discogs');
+    });
+  });
+
+  describe('using Last.fm', () => {
+    beforeEach(() => {
+      cy.visit('/scrobble/album/search/Meteora?source=lastfm');
+      cy.wait('@userData');
+    });
+
+    it('displays dropdown for data sources', () => {
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').should('exist');
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').click();
+      cy.get('[data-cy="DataSourceDropdown-menu"]').children().should('have.length', 2);
+      // check active item matches data source
+      cy.get('[data-cy="DataSourceDropdown-menu"]')
+        .children('button.active')
+        .should('have.text', 'Last.fm');
+    });
+
+    it('switches data source to Discogs', () => {
+      // check initial Last.fm results
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .parent()
+        .should('have.attr', 'href')
+        .and('match', /https:\/\/www.last.fm\/music\/.*\/.*/);
+
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').click();
+      cy.get('[data-cy="DataSourceDropdown-menu"]')
+        .find('[data-cy="DataSourceDropdown-item-discogs"]')
+        .click();
+        
+      // check Discogs results
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .parent()
+        .should('have.attr', 'href')
+        .and('match', /https:\/\/www.discogs.com\/master\/.*/);
+    });
+
+    it('displays static data source on album view', () => {
+      cy.get('[data-cy="AlbumCard"]')
+        .first()
+        .click();
+
+      cy.location('pathname').should('match', /scrobble\/album\/view/);
+
+      cy.get('[data-cy="DataSourceDropdown-toggle"]').should('not.exist');
+      cy.get('[data-cy="AlbumBreadcrumb-provider"]').should('have.text', 'Last.fm');
+    });
+  });
+});

--- a/cypress/e2e/scrobbleAlbum/scrobble-album-data-source.spec.js
+++ b/cypress/e2e/scrobbleAlbum/scrobble-album-data-source.spec.js
@@ -51,7 +51,7 @@ describe('Scrobble album data source (SRP)', () => {
       cy.get('[data-cy="DataSourceDropdown-menu"]')
         .find('[data-cy="DataSourceDropdown-item-lastfm"]')
         .click();
-        
+
       // check Last.fm results
       cy.get('[data-cy="AlbumCard"]')
         .first()
@@ -100,7 +100,7 @@ describe('Scrobble album data source (SRP)', () => {
       cy.get('[data-cy="DataSourceDropdown-menu"]')
         .find('[data-cy="DataSourceDropdown-item-discogs"]')
         .click();
-        
+
       // check Discogs results
       cy.get('[data-cy="AlbumCard"]')
         .first()

--- a/src/domains/scrobbleAlbum/ScrobbleAlbumResults.tsx
+++ b/src/domains/scrobbleAlbum/ScrobbleAlbumResults.tsx
@@ -49,7 +49,7 @@ export function ScrobbleAlbumResults() {
         <FontAwesomeIcon icon={faCompactDisc} className="me-2" />
         <Trans i18nKey="scrobbleAlbum">Scrobble Album</Trans>
       </h2>
-      <AlbumBreadcrumb albumQuery={query} dataProvider={dataProvider} />
+      <AlbumBreadcrumb albumQuery={query} dataProvider={dataProvider} showProviderDropdown={true} />
       <Row className="mb-4">
         <div className="col-md-8">
           {isFetching ? <Spinner /> : <AlbumResults albums={data} query={query} useFullWidth={false} />}

--- a/src/domains/scrobbleAlbum/partials/AlbumBreadcrumb.tsx
+++ b/src/domains/scrobbleAlbum/partials/AlbumBreadcrumb.tsx
@@ -5,7 +5,7 @@ import { Breadcrumb, BreadcrumbItem } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCompactDisc, faUser } from '@fortawesome/free-solid-svg-icons';
 
-import { PROVIDER_NAME } from 'Constants';
+import ProviderItem from './ProviderItem';
 
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { Album, DiscogsAlbum, LastFmAlbum } from 'utils/types/album';
@@ -29,6 +29,7 @@ interface AlbumBreadcrumbProps {
   artistQuery?: string;
   artistDiscogsId?: string;
   dataProvider?: string;
+  showProviderDropdown?: boolean;
 }
 
 export default function AlbumBreadcrumb({
@@ -37,6 +38,7 @@ export default function AlbumBreadcrumb({
   artistDiscogsId,
   album,
   dataProvider,
+  showProviderDropdown,
 }: AlbumBreadcrumbProps) {
   const { t } = useTranslation();
   const itemList = [generateBreadcrumbItem('/scrobble/album', t('search'), { provider: dataProvider })];
@@ -98,7 +100,7 @@ export default function AlbumBreadcrumb({
       {itemList}
       {dataProvider && (
         <div className="flex-grow-1 text-end">
-          {t('dataProvider')}: <span data-cy="AlbumBreadcrumb-provider">{PROVIDER_NAME[dataProvider]}</span>
+          <ProviderItem dataProvider={dataProvider} showDropdown={showProviderDropdown} />
         </div>
       )}
     </Breadcrumb>

--- a/src/domains/scrobbleAlbum/partials/ProviderItem.tsx
+++ b/src/domains/scrobbleAlbum/partials/ProviderItem.tsx
@@ -28,17 +28,22 @@ export default function ProviderItem({ dataProvider, showDropdown }: ProviderDro
     return (
       <>
         <UncontrolledDropdown data-cy="DataSourceDropdown" nav inNavbar={bsBreakpoint < BS_SIZE_MD}>
-          <DropdownToggle nav caret className="ows-dropdown-user">
+          <DropdownToggle nav caret className="ows-dropdown-user" data-cy="DataSourceDropdown-toggle">
             {t('dataProvider')}: <span data-cy="AlbumBreadcrumb-provider">{PROVIDER_NAME[dataProvider]}</span>
           </DropdownToggle>
-          <DropdownMenu end>
+          <DropdownMenu end data-cy="DataSourceDropdown-menu">
             <DropdownItem
               active={dataProvider === PROVIDER_DISCOGS}
               onClick={() => changeDataProvider(PROVIDER_DISCOGS)}
+              data-cy={`DataSourceDropdown-item-${PROVIDER_DISCOGS}`}
             >
               {PROVIDER_NAME[PROVIDER_DISCOGS]}
             </DropdownItem>
-            <DropdownItem active={dataProvider === PROVIDER_LASTFM} onClick={() => changeDataProvider(PROVIDER_LASTFM)}>
+            <DropdownItem
+              active={dataProvider === PROVIDER_LASTFM}
+              onClick={() => changeDataProvider(PROVIDER_LASTFM)}
+              data-cy={`DataSourceDropdown-item-${PROVIDER_LASTFM}`}
+            >
               {PROVIDER_NAME[PROVIDER_LASTFM]}
             </DropdownItem>
           </DropdownMenu>

--- a/src/domains/scrobbleAlbum/partials/ProviderItem.tsx
+++ b/src/domains/scrobbleAlbum/partials/ProviderItem.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown } from 'reactstrap';
+
+import { BS_SIZE_MD, useBootstrapBreakpoint } from 'utils/bootstrapBreakpoints';
+
+import { PROVIDER_DISCOGS, PROVIDER_LASTFM, PROVIDER_NAME } from 'Constants';
+
+interface ProviderDropdownProps {
+  dataProvider: string;
+  showDropdown?: boolean;
+}
+
+export default function ProviderItem({ dataProvider, showDropdown }: ProviderDropdownProps) {
+  const navigate = useNavigate();
+  const bsBreakpoint = useBootstrapBreakpoint();
+  const { t } = useTranslation();
+
+  const changeDataProvider = (provider) => {
+    navigate('.', {
+      replace: true,
+      state: { provider },
+    });
+  };
+
+  if (showDropdown) {
+    return (
+      <>
+        <UncontrolledDropdown data-cy="DataSourceDropdown" nav inNavbar={bsBreakpoint < BS_SIZE_MD}>
+          <DropdownToggle nav caret className="ows-dropdown-user">
+            {t('dataProvider')}: <span data-cy="AlbumBreadcrumb-provider">{PROVIDER_NAME[dataProvider]}</span>
+          </DropdownToggle>
+          <DropdownMenu end>
+            <DropdownItem
+              active={dataProvider === PROVIDER_DISCOGS}
+              onClick={() => changeDataProvider(PROVIDER_DISCOGS)}
+            >
+              {PROVIDER_NAME[PROVIDER_DISCOGS]}
+            </DropdownItem>
+            <DropdownItem active={dataProvider === PROVIDER_LASTFM} onClick={() => changeDataProvider(PROVIDER_LASTFM)}>
+              {PROVIDER_NAME[PROVIDER_LASTFM]}
+            </DropdownItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
+      </>
+    );
+  }
+  return (
+    <>
+      {t('dataProvider')}: <span data-cy="AlbumBreadcrumb-provider">{PROVIDER_NAME[dataProvider]}</span>
+    </>
+  );
+}


### PR DESCRIPTION
After searching for an album, the data source can only be changed by going back to the search form.

On the album results page, the static display of the data source has been changed to a dropdown to facilitate switching. After selecting an album, it goes back to the static text, as switching data sources at this point doesn't really make sense.

Addresses #275.

<img width="1318" height="194" alt="Screenshot 2026-03-25 at 9 47 09 AM" src="https://github.com/user-attachments/assets/5b2188da-1cf9-4dc1-b4e0-c7f5999bf31b" />

## Changes

* `src/domains/scrobbleAlbum/partials/ProviderItem.tsx`
  * New component to handle either dropdown or static display of the data source based on `showDropdown` prop
*  `src/domains/scrobbleAlbum/partials/AlbumBreadcrumb.tsx`
    * Use new `ProviderItem` to display the data source
    * New prop `showProviderDropdown` that gets passed to `ProviderItem`
*  `src/domains/scrobbleAlbum/ScrobbleAlbumResults.tsx`
    * Set `showProviderDropdown` on `AlbumBreadcrumb` to show the new dropdown 
* Other instances of `AlbumBreadcrumb` are unchanged and will show static text

## Tests

* `cypress/e2e/scrobbleAlbum/scrobble-album-data-source.spec.js`
  * Tests to assert the dropdown displays on the search results page, switching works, and static display shown on the album page

I haven't worked with Cypress before, so please let me know if any changes are needed with the tests. 